### PR TITLE
Fix Waila takes all server tick time when looking at the another player

### DIFF
--- a/src/main/java/net/darkhax/wawla/addons/generic/AddonGenericEntities.java
+++ b/src/main/java/net/darkhax/wawla/addons/generic/AddonGenericEntities.java
@@ -3,7 +3,6 @@ package net.darkhax.wawla.addons.generic;
 import java.util.List;
 
 import net.darkhax.wawla.util.Utilities;
-import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.passive.EntityAnimal;

--- a/src/main/java/net/darkhax/wawla/addons/generic/AddonGenericEntities.java
+++ b/src/main/java/net/darkhax/wawla/addons/generic/AddonGenericEntities.java
@@ -3,10 +3,12 @@ package net.darkhax.wawla.addons.generic;
 import java.util.List;
 
 import net.darkhax.wawla.util.Utilities;
+import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.passive.EntityTameable;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -102,9 +104,10 @@ public class AddonGenericEntities implements IWailaEntityProvider {
 
     @Override
     public NBTTagCompound getNBTData(EntityPlayerMP player, Entity entity, NBTTagCompound tag, World world) {
+        if (entity == null) return tag;
+        if (entity instanceof EntityPlayer) return tag;
 
-        if (entity != null) entity.writeToNBT(tag);
-
+        entity.writeToNBT(tag);
         return tag;
     }
 


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16112

Remove sending a whole player entity while looking at him, since isn't actually used